### PR TITLE
Bump appVersion and add extraArgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Ability to configure extra arguments for the oauth2-proxy container per provider (`oauth2Proxy.provider[].extraArgs`)
+- Ability to configure extra arguments for the oauth2-proxy container for all providers (`oauth2Proxy.extraArgs`)
+
+### Changed
+
+- Upgrade to upstream version [v7.2.0](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.2.0)
+
 ## [2.3.0] - 2021-11-08
 
-### Changed 
+### Changed
 
 - Allow disabling TLS.
 

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: oauth2-proxy
 description: A reverse proxy that provides authentication with Google, Azure, OpenID Connect and many more identity providers
 home: https://github.com/giantswarm/oauth2-proxy-app
-version: "2.0.0"
-appVersion: "7.1.3"
+version: "2.4.0"
+appVersion: "7.2.0"
 annotations:
   application.giantswarm.io/team: team-rainbow
   config.giantswarm.io/version: 1.x.x

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
         runAsUser: {{ $.Values.userID }}
         runAsGroup: {{ $.Values.groupID }}
       containers:
-      - image: {{ $.Values.registry.domain }}/giantswarm/oauth2-proxy:v7.1.3
+      - image: {{ $.Values.registry.domain }}/giantswarm/oauth2-proxy:v7.2.0
         name: {{ include "resource.default.name" $ }}
         args:
         - --cookie-expire={{ $.Values.oauth2Proxy.cookie.expiry }}
@@ -66,6 +66,12 @@ spec:
         - --cookie-secure=false
         {{- end }}
         - --upstream=file:///dev/null
+        {{- with $provider.extraArgs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+        {{- with $.Values.oauth2Proxy.extraArgs }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         env:
         - name: OAUTH2_PROXY_CLIENT_ID
           valueFrom:

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -41,3 +41,5 @@ oauth2Proxy:
     clientID: ""
     clientSecret: ""
     cookieSecret: ""
+    extraArgs: []
+  extraArgs: []


### PR DESCRIPTION
This PR

- updates the used container image to v7.2.0
- Adds the ability to configure extra arguments per provider and globally