### PR TITLE
Add name override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `nameOverride` to values
+
 ## [2.4.0] - 2021-11-16
 
 ### Added

--- a/helm/oauth2-proxy/templates/_helpers.tpl
+++ b/helm/oauth2-proxy/templates/_helpers.tpl
@@ -42,5 +42,5 @@ characters for resource names, the stem is truncated to 47 characters to leave
 room for such suffix.
 */}}
 {{- define "resource.default.name" -}}
-{{- .Release.Name | replace "." "-" | trunc 47 | trimSuffix "-" -}}
+{{- default .Release.Name .Values.nameOverride | replace "." "-" | trunc 47 | trimSuffix "-" -}}
 {{- end -}}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -1,3 +1,6 @@
+# Use nameOverride to change the names of resources
+# nameOverride: "my-oauth2-proxy"
+
 port:
   name: oauth2-proxy
   port: 4180


### PR DESCRIPTION
This PR adds the ability to override the name used in rendered resources. This is useful when this chart is used as a sub-chart.

Sub-charts receive the same `.Relese.Name` as the parent chart, so by specifying `nameOverride`, one can make sure resources from the sub-chart are not overwriting resources from the parent chart.