### PR TITLE
allow for multiple Hosts

### DIFF
--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:
+  {{- if eq (len .Values.ingress.hosts) 0 -}}
   - host: {{ $.Values.ingress.host }}
     http:
       paths:
@@ -50,10 +51,51 @@ spec:
         {{- end}}
         pathType: ImplementationSpecific
       {{- end }}
+  {{- end }}
+  {{- range .Values.ingress.hosts }}
+  - host: {{ tpl . $ }}
+    http:
+      paths:
+      {{- range $provider := $.Values.oauth2Proxy.providers }}
+      - backend:
+        {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          service:
+          {{- if eq (len $.Values.oauth2Proxy.providers) 1}}
+            name: {{ include "resource.default.name"  $ }}
+          {{- else }}
+            name: {{ $provider.id }}-{{ include "resource.default.name"  $ }}
+          {{- end}}
+            port:
+              number: {{ $.Values.port.port }}
+        {{- else }}
+        {{- if eq (len $.Values.oauth2Proxy.providers) 1}}
+          serviceName: {{ include "resource.default.name"  $ }}
+        {{- else }}
+          serviceName: {{ $provider.id }}-{{ include "resource.default.name"  $ }}
+        {{- end}}
+          servicePort: {{ $.Values.port.port }}
+        {{- end }}
+      {{- if eq (len $.Values.oauth2Proxy.providers) 1}}
+        path: /oauth2
+      {{- else }}
+        path: /{{ $provider.id }}/oauth2
+      {{- end}}
+        pathType: ImplementationSpecific
+      {{- end }}
+    {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
+
+  {{- if eq (len .Values.ingress.hosts) 0 -}}
   - hosts:
     - {{ $.Values.ingress.host }}
     secretName: {{ $.Values.ingress.certSecretName }}
+  {{- end }}
+
+  {{- range .Values.ingress.hosts }}
+  - hosts:
+    - {{ tpl . $ }}
+    secretName: oauth-proxy-{{ regexReplaceAll "\\W+" (tpl . $) "-" }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -18,6 +18,8 @@ ingress:
   tls:
     enabled: true
   host: ""
+  # If used, will replace host
+  hosts: []
   certSecretName: "oauth2-proxy"
   className: "nginx"
   # Additional annotations to apply to the ingress.


### PR DESCRIPTION
At the moment only one host can be provided.

Because of that, customers need to create one managed app per Host.

Our need is to be able to provide multable hosts.

A Value hosts is added.

If the Array hosts is empy, the host is used, just like before this pr.

If the Array hosts is not empty, host will not be used.