### PR TITLE
Allow for multiple host names (#84)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ More options can be found in the [command line options documentation](https://oa
 1. Add following annotations to the existing ingress:
     ```yaml
     annotations:
-      nginx.ingress.kubernetes.io/auth-signin: https://$host/oauth2/start
-      nginx.ingress.kubernetes.io/auth-url: https://$host/oauth2/auth
+      nginx.ingress.kubernetes.io/auth-signin: https://HOST/oauth2/start
+      nginx.ingress.kubernetes.io/auth-url: https://HOST/oauth2/auth
     ```
 
 2. Create a new oauth2 ingress together with the existing ingress

--- a/README.md
+++ b/README.md
@@ -48,11 +48,10 @@ More options can be found in the [command line options documentation](https://oa
           paths:
           - backend:
               service:
-                  name: oauth2-proxy
-                  port:
+                name: oauth2-proxy
+                port:
                   number: 4180
             path: /oauth2
-            pathType: ImplementationSpecific
     ```
 
     If TLS is enabled, add the same certificate from the existing ingress, to the oauth2 ingress.

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ More options can be found in the [command line options documentation](https://oa
                 port:
                   number: 4180
             path: /oauth2
+            pathType: Prefix
     ```
 
     If TLS is enabled, add the same certificate from the existing ingress, to the oauth2 ingress.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ It is build upon the [oauth2-proxy/oauth2-proxy](https://github.com/oauth2-proxy
 
 More options can be found in the [command line options documentation](https://oauth2-proxy.github.io/oauth2-proxy/docs/configuration/overview/#command-line-options).
 
-
 ## Current supported Services at Giant Swarm
 
 - Prometheus operator managed Prometheus and Alertmanager
@@ -27,6 +26,7 @@ More options can be found in the [command line options documentation](https://oa
 ## Add authentication/authorization to a web frontend
 
 1. Add following annotations to the existing ingress:
+
     ```yaml
     annotations:
       nginx.ingress.kubernetes.io/auth-signin: https://HOST/oauth2/start
@@ -54,16 +54,16 @@ More options can be found in the [command line options documentation](https://oa
             path: /oauth2
             pathType: ImplementationSpecific
     ```
-    
+
     If TLS is enabled, add the same certificate from the existing ingress, to the oauth2 ingress.
 
 3. Add to Service URL to the list of allowed Callback URLs in [Auth0](https://manage.auth0.com/#/):
 
     Navigate to the Application `OAuth2-Proxy` and enter the service URL in the
     list of allowed Callback URLs with the following scheme:
-    ```
+
+    ```nohighlight
     https://{{ Your.Service.URL }}/oauth2/callback
     ```
+
     This has to be done for every installation separately.
-
-

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ More options can be found in the [command line options documentation](https://oa
 2. Create a new oauth2 ingress together with the existing ingress
 
     ```yaml
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
     name: {{ Your.Service.Name }}-oauth2-proxy
@@ -45,11 +45,14 @@ More options can be found in the [command line options documentation](https://oa
     rules:
     - host: {{ Your.Service.URL }}
         http:
-        paths:
-        - path: /oauth2
-            backend:
-            serviceName: oauth2-proxy
-            servicePort: 4180
+          paths:
+          - backend:
+              service:
+                  name: oauth2-proxy
+                  port:
+                  number: 4180
+            path: /oauth2
+            pathType: ImplementationSpecific
     ```
     
     If TLS is enabled, add the same certificate from the existing ingress, to the oauth2 ingress.

--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
 spec:
   ingressClassName: {{ .Values.ingress.className | quote }}
   rules:
+  {{- if eq (len .Values.ingress.hosts) 0 -}}
   - host: {{ $.Values.ingress.host }}
     http:
       paths:
@@ -50,10 +51,51 @@ spec:
         {{- end}}
         pathType: ImplementationSpecific
       {{- end }}
+  {{- end }}
+  {{- range .Values.ingress.hosts }}
+  - host: {{ tpl . $ }}
+    http:
+      paths:
+      {{- range $provider := $.Values.oauth2Proxy.providers }}
+      - backend:
+        {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+          service:
+          {{- if eq (len $.Values.oauth2Proxy.providers) 1}}
+            name: {{ include "resource.default.name"  $ }}
+          {{- else }}
+            name: {{ $provider.id }}-{{ include "resource.default.name"  $ }}
+          {{- end}}
+            port:
+              number: {{ $.Values.port.port }}
+        {{- else }}
+        {{- if eq (len $.Values.oauth2Proxy.providers) 1}}
+          serviceName: {{ include "resource.default.name"  $ }}
+        {{- else }}
+          serviceName: {{ $provider.id }}-{{ include "resource.default.name"  $ }}
+        {{- end}}
+          servicePort: {{ $.Values.port.port }}
+        {{- end }}
+      {{- if eq (len $.Values.oauth2Proxy.providers) 1}}
+        path: /oauth2
+      {{- else }}
+        path: /{{ $provider.id }}/oauth2
+      {{- end}}
+        pathType: ImplementationSpecific
+      {{- end }}
+    {{- end }}
   {{- if .Values.ingress.tls.enabled }}
   tls:
+
+  {{- if eq (len .Values.ingress.hosts) 0 -}}
   - hosts:
     - {{ $.Values.ingress.host }}
     secretName: {{ $.Values.ingress.certSecretName }}
+  {{- end }}
+
+  {{- range .Values.ingress.hosts }}
+  - hosts:
+    - {{ tpl . $ }}
+    secretName: oauth-proxy-{{ regexReplaceAll "\\W+" (tpl . $) "-" }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/ingress.yaml
+++ b/helm/oauth2-proxy/templates/ingress.yaml
@@ -90,12 +90,16 @@ spec:
   - hosts:
     - {{ $.Values.ingress.host }}
     secretName: {{ $.Values.ingress.certSecretName }}
-  {{- end }}
-
+  {{- else if eq (len .Values.ingress.hosts) 1 }}
+  - hosts:
+    - {{ .Values.ingress.hosts | index 0 }}
+    secretName: {{ $.Values.ingress.certSecretName }}
+  {{- else }}
   {{- range .Values.ingress.hosts }}
   - hosts:
     - {{ tpl . $ }}
     secretName: oauth-proxy-{{ regexReplaceAll "\\W+" (tpl . $) "-" }}
+  {{- end }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/secret.yaml
+++ b/helm/oauth2-proxy/templates/secret.yaml
@@ -20,6 +20,6 @@ data:
   {{- if $provider.cookieSecret }}
   {{ $provider.id }}-cookie-secret: {{ $provider.cookieSecret | b64enc | quote }}
   {{- end }}
-  {{- end}}
+  {{- end }}
   {{- end }}
   

--- a/helm/oauth2-proxy/values.schema.json
+++ b/helm/oauth2-proxy/values.schema.json
@@ -23,6 +23,9 @@
                 "host": {
                     "type": "string"
                 },
+                "hosts": {
+                    "type": "array"
+                },
                 "letsencrypt": {
                     "type": "object",
                     "properties": {

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -17,7 +17,10 @@ ingress:
     enabled: true
   tls:
     enabled: true
+  # Deprecated. Please use the `hosts` array instead. `host` will be removed with the next major release.
   host: ""
+  # `hosts` is used to configure one or several host names to listen to. Takes precedence over `host`, unless it's an empty array.
+  hosts: []
   certSecretName: "oauth2-proxy"
   className: "nginx"
   # Additional annotations to apply to the ingress.

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -12,17 +12,27 @@ registry:
   domain: docker.io
 
 ingress:
+  # Set to true to create an ingress resource for the oauth2-proxy service.
   enabled: false
+
+  # Automatically fetch certificate(s) from Let's Encrypt
+  # (requires cert-manager)
   letsencrypt:
     enabled: true
+
   tls:
     enabled: true
+
   # Deprecated. Please use the `hosts` array instead. `host` will be removed with the next major release.
   host: ""
   # `hosts` is used to configure one or several host names to listen to. Takes precedence over `host`, unless it's an empty array.
   hosts: []
+  # Prefix of the TLS secrets in the case of multiple hosts,
+  # or name of the secret in case of only one host (if Let's Encrypt is enabled)
   certSecretName: "oauth2-proxy"
+  
   className: "nginx"
+  
   # Additional annotations to apply to the ingress.
   extraAnnotations: {}
   # key: value
@@ -46,6 +56,7 @@ oauth2Proxy:
     provider: "oidc"
     clientID: ""
     clientSecret: ""
+    # cookieSecret must be 16, 24, or 32 bytes long
     cookieSecret: ""
     extraArgs: []
   extraArgs: []

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -30,9 +30,9 @@ ingress:
   # Prefix of the TLS secrets in the case of multiple hosts,
   # or name of the secret in case of only one host (if Let's Encrypt is enabled)
   certSecretName: "oauth2-proxy"
-  
+
   className: "nginx"
-  
+
   # Additional annotations to apply to the ingress.
   extraAnnotations: {}
   # key: value


### PR DESCRIPTION
Based on https://github.com/giantswarm/oauth2-proxy-app/pull/84 by @johannges

## How this should be tested

- New workload cluster with NGINX ingress controller and cert-manager installed
- Two host names configured
- Auth0 as OAuth provider