### PR TITLE
Use SeccompProfile, disable PSP on 1.25, add PDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.8.0] - 2023-02-01
+### Added
 
+- Add PodDisruptionBudget with `maxUnavailable: "25%"`
+- Usage of SeccompProfile in Pod and Container securityContext
+
+### Changed
+
+- Include PodSecurityPolicies only if available. Adds support for Kubernetes 1.25 and higher
+
+## [2.8.0] - 2023-02-01
 
 ### Added
 

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -35,6 +35,9 @@ spec:
       securityContext:
         runAsUser: {{ $.Values.userID }}
         runAsGroup: {{ $.Values.groupID }}
+        {{- with $.Values.podSecurityContext }}
+          {{- . | toYaml | nindent 8 }}
+        {{- end }}
       containers:
       - image: {{ $.Values.registry.domain }}/giantswarm/oauth2-proxy:v7.2.1
         name: {{ include "resource.default.name" $ }}
@@ -114,4 +117,8 @@ spec:
           requests:
             cpu: 100m
             memory: 100Mi
+        securityContext:
+          {{- with $.Values.securityContext }}
+            {{- . | toYaml | nindent 10 }}
+          {{- end }}
 {{- end }}

--- a/helm/oauth2-proxy/templates/psp.yaml
+++ b/helm/oauth2-proxy/templates/psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:
@@ -5,6 +6,8 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "labels.common" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'runtime/default'
 spec:
   privileged: false
   fsGroup:
@@ -27,3 +30,5 @@ spec:
   hostNetwork: true
   hostIPC: false
   hostPID: true
+  volumes: []
+{{- end }}

--- a/helm/oauth2-proxy/templates/rbac.yaml
+++ b/helm/oauth2-proxy/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1beta1" }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -28,3 +29,4 @@ roleRef:
   kind: ClusterRole
   name: {{ include "resource.default.name" . }}
   apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/helm/oauth2-proxy/templates/serviceaccount.yaml
+++ b/helm/oauth2-proxy/templates/serviceaccount.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: {{ include "resource.default.name" . }}
   namespace: {{ .Release.Namespace }}
+automountServiceAccountToken: false

--- a/helm/oauth2-proxy/values.schema.json
+++ b/helm/oauth2-proxy/values.schema.json
@@ -127,6 +127,19 @@
                 }
             }
         },
+        "podSecurityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "port": {
             "type": "object",
             "properties": {
@@ -143,6 +156,19 @@
             "properties": {
                 "domain": {
                     "type": "string"
+                }
+            }
+        },
+        "securityContext": {
+            "type": "object",
+            "properties": {
+                "seccompProfile": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "type": "string"
+                        }
+                    }
                 }
             }
         },

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -66,3 +66,13 @@ oauth2Proxy:
   extraEnv: []
   # - name: key
   #   value: value
+
+# Add seccomp to pod security context
+podSecurityContext:
+  seccompProfile:
+    type: RuntimeDefault
+
+# Add seccomp to container security context
+securityContext:
+  seccompProfile:
+    type: RuntimeDefault


### PR DESCRIPTION
This PR

- adds a PDB with  `maxUnavailable: "25%"`
- enables usage of default SeccompProfile
- Disable PSP on k8s 1.25 and higher