### PR TITLE
Update security context settings for PSS restricted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update default security context values to make the chart comply to PodSecurityStandard restricted profile.
+
 ### Removed
 
 - Stop pushing to `openstack-app-collection`.

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -69,10 +69,15 @@ oauth2Proxy:
 
 # Add seccomp to pod security context
 podSecurityContext:
+  runAsNonRoot: true
   seccompProfile:
     type: RuntimeDefault
 
 # Add seccomp to container security context
 securityContext:
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop:
+    - ALL
   seccompProfile:
     type: RuntimeDefault


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/27339

This PR changes the security context default values to make the deployment in chart comply to the PodSecurityStandard restricted profile 