### PR TITLE
bump oauth2-proxy and add new args for jwt passthrough

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,30 +10,6 @@ workflows:
       - architect/push-to-app-catalog:
           context: architect
           executor: app-build-suite
-          name: push-to-default-app-catalog
-          app_catalog: "default-catalog"
-          app_catalog_test: "default-test-catalog"
-          chart: "oauth2-proxy"
-          filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-catalog:
-          context: architect
-          executor: app-build-suite
-          name: push-to-giantswarm-app-catalog
-          app_catalog: "giantswarm-catalog"
-          app_catalog_test: "giantswarm-test-catalog"
-          chart: "oauth2-proxy"
-          filters:
-            # Trigger the job also on git tag.
-            tags:
-              only: /^v.*/
-
-      - architect/push-to-app-catalog:
-          context: architect
-          executor: app-build-suite
           name: push-to-control-plane-app-catalog
           app_catalog: "control-plane-catalog"
           app_catalog_test: "control-plane-test-catalog"
@@ -49,6 +25,62 @@ workflows:
           app_name: oauth2-proxy
           app_namespace: monitoring
           app_collection_repo: aws-app-collection
+          requires:
+            - push-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-to-capa-app-collection
+          context: architect
+          app_name: oauth2-proxy
+          app_namespace: monitoring
+          app_collection_repo: capa-app-collection
+          requires:
+            - push-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-to-capz-app-collection
+          context: architect
+          app_name: oauth2-proxy
+          app_namespace: monitoring
+          app_collection_repo: capz-app-collection
+          requires:
+            - push-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-to-vsphere-app-collection
+          context: architect
+          app_name: oauth2-proxy
+          app_namespace: monitoring
+          app_collection_repo: vsphere-app-collection
+          requires:
+            - push-to-control-plane-app-catalog
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/
+
+      - architect/push-to-app-collection:
+          name: push-to-cloud-director-app-collection
+          context: architect
+          app_name: oauth2-proxy
+          app_namespace: monitoring
+          app_collection_repo: cloud-director-app-collection
           requires:
             - push-to-control-plane-app-catalog
           filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add new configuration flags needed to let jwt token through.
+
 ### Changed
 
 - Upgrade oauth2-proxy container image tag to [v7.7.0](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.7.0)
-- Add new configuration flags needed to let jwt token through.
+
+### Removed
+
 - Removes oauth2-proxy from non control plane related catalogs.
 
 ## [2.13.0] - 2023-12-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade oauth2-proxy container image tag to [v7.7.0](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.7.0)
+- Add new configuration flags needed to let jwt token through.
+- Removes oauth2-proxy from non control plane related catalogs.
+
 ## [2.13.0] - 2023-12-12
 
 ### Changed

--- a/helm/oauth2-proxy/Chart.yaml
+++ b/helm/oauth2-proxy/Chart.yaml
@@ -3,7 +3,7 @@ name: oauth2-proxy
 description: A reverse proxy that provides authentication with Google, Azure, OpenID Connect and many more identity providers
 home: https://github.com/giantswarm/oauth2-proxy-app
 version: "2.13.0"
-appVersion: "7.5.1"
+appVersion: "7.7.0"
 annotations:
   application.giantswarm.io/team: atlas
   config.giantswarm.io/version: 1.x.x

--- a/helm/oauth2-proxy/templates/deployment.yaml
+++ b/helm/oauth2-proxy/templates/deployment.yaml
@@ -43,35 +43,40 @@ spec:
         name: {{ include "resource.default.name" $ }}
         args:
         - --cookie-expire={{ $.Values.oauth2Proxy.cookie.expiry }}
+        - --cookie-name={{ $.Values.oauth2Proxy.cookie.name }}
         - --cookie-refresh={{ $.Values.oauth2Proxy.cookie.refresh }}
-        - --email-domain={{ $.Values.oauth2Proxy.emailDomain }}
-        - --http-address=0.0.0.0:4180
-        - --provider={{ $provider.provider | default $.Values.oauth2Proxy.defaultProvider }}
-        - --set-authorization-header={{ $.Values.oauth2Proxy.setAuthorizationHeader }}
-        - --skip-provider-button={{ $.Values.oauth2Proxy.skipProviderButton }}
-        {{- if $.Values.oauth2Proxy.oidc.issuerURL }}
-        - --oidc-issuer-url={{ $.Values.oauth2Proxy.oidc.issuerURL }}
-        {{- end }}
-        {{- if $.Values.oauth2Proxy.oidc.loginURL }}
-        - --login-url={{ $.Values.oauth2Proxy.oidc.loginURL }}
-        {{- end }}
-        {{- if $.Values.oauth2Proxy.oidc.redeemURL }}
-        - --redeem-url={{ $.Values.oauth2Proxy.oidc.redeemURL }}
-        {{- end }}
-        {{- if $.Values.oauth2Proxy.oidc.profileURL }}
-        - --profile-url={{ $.Values.oauth2Proxy.oidc.profileURL }}
-        {{- end }}
-        {{- if $.Values.oauth2Proxy.oidc.validateURL }}
-        - --validate-url={{ $.Values.oauth2Proxy.oidc.validateURL }}
-        {{- end }}
         {{- if $provider.cookieSecret }}
         - --cookie-secure=true
         {{- else }}
         - --cookie-secure=false
         {{- end }}
-        - --upstream=file:///dev/null
+        - --email-domain={{ $.Values.oauth2Proxy.emailDomain }}
+        - --http-address=0.0.0.0:4180
+        {{- if $.Values.oauth2Proxy.oidc.loginURL }}
+        - --login-url={{ $.Values.oauth2Proxy.oidc.loginURL }}
+        {{- end }}
         {{- if $.Values.serviceMonitor.enabled }}
         - --metrics-address=0.0.0.0:44180
+        {{- end }}
+        - --passAccessToken={{ $.Values.oauth2Proxy.passAccessToken }}
+        - --passAuthorizationHeader={{ $.Values.oauth2Proxy.passAuthorizationHeader }}
+        {{- if $.Values.oauth2Proxy.oidc.profileURL }}
+        - --profile-url={{ $.Values.oauth2Proxy.oidc.profileURL }}
+        {{- end }}
+        - --provider={{ $provider.provider | default $.Values.oauth2Proxy.defaultProvider }}
+        {{- if $.Values.oauth2Proxy.oidc.issuerURL }}
+        - --oidc-issuer-url={{ $.Values.oauth2Proxy.oidc.issuerURL }}
+        {{- end }}
+        {{- if $.Values.oauth2Proxy.oidc.redeemURL }}
+        - --redeem-url={{ $.Values.oauth2Proxy.oidc.redeemURL }}
+        {{- end }}
+        - --set-authorization-header={{ $.Values.oauth2Proxy.setAuthorizationHeader }}
+        - --set-xauthrequest={{ $.Values.oauth2Proxy.setXAuthRequest }}
+        - --skip-jwt-bearer-tokens={{ $.Values.oauth2Proxy.skipJwtBearerTokens }}
+        - --skip-provider-button={{ $.Values.oauth2Proxy.skipProviderButton }}
+         - --upstream=file:///dev/null
+        {{- if $.Values.oauth2Proxy.oidc.validateURL }}
+        - --validate-url={{ $.Values.oauth2Proxy.oidc.validateURL }}
         {{- end }}
         {{- with $provider.extraArgs }}
         {{- toYaml . | nindent 8 }}

--- a/helm/oauth2-proxy/values.schema.json
+++ b/helm/oauth2-proxy/values.schema.json
@@ -66,6 +66,9 @@
                         "expiry": {
                             "type": "string"
                         },
+                        "name": {
+                            "type": "string"
+                        },
                         "refresh": {
                             "type": "string"
                         }
@@ -103,6 +106,12 @@
                         }
                     }
                 },
+                "passAccessToken": {
+                    "type": "boolean"
+                },
+                "passAuthorizationHeader": {
+                    "type": "boolean"
+                },
                 "providers": {
                     "type": "array",
                     "items": {
@@ -116,9 +125,6 @@
                             },
                             "cookieSecret": {
                                 "type": "string"
-                            },
-                            "existingSecret": {
-                                "type": ["null", "string"]
                             },
                             "extraArgs": {
                                 "type": "array"
@@ -135,6 +141,12 @@
                 "setAuthorizationHeader": {
                     "type": "boolean"
                 },
+                "setXAuthRequest": {
+                    "type": "boolean"
+                },
+                "skipJwtBearerTokens": {
+                    "type": "boolean"
+                },
                 "skipProviderButton": {
                     "type": "boolean"
                 }
@@ -143,6 +155,9 @@
         "podSecurityContext": {
             "type": "object",
             "properties": {
+                "runAsNonRoot": {
+                    "type": "boolean"
+                },
                 "seccompProfile": {
                     "type": "object",
                     "properties": {
@@ -175,6 +190,23 @@
         "securityContext": {
             "type": "object",
             "properties": {
+                "allowPrivilegeEscalation": {
+                    "type": "boolean"
+                },
+                "capabilities": {
+                    "type": "object",
+                    "properties": {
+                        "drop": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                },
+                "readOnlyRootFilesystem": {
+                    "type": "boolean"
+                },
                 "seccompProfile": {
                     "type": "object",
                     "properties": {

--- a/helm/oauth2-proxy/values.yaml
+++ b/helm/oauth2-proxy/values.yaml
@@ -41,10 +41,15 @@ oauth2Proxy:
   defaultProvider: oidc
   cookie:
     expiry: 24h0m0s
+    name: SESSION
     refresh: 0h60m0s
   emailDomain: "*"
+  passAccessToken: true
+  passAuthorizationHeader: true
   setAuthorizationHeader: true
+  setXAuthRequest: true
   skipProviderButton: true
+  skipJwtBearerTokens: true
   oidc:
     issuerURL: ""
     loginURL: ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3568

This pull request includes several updates related to the `oauth2-proxy` configuration and deployment process. The changes involve updates to the CircleCI workflow, Helm chart, deployment template, and configuration values. 

### Workflow Updates:

* Updated `.circleci/config.yml` to only push the app to control plane catalogs.

### Helm Chart Updates:

* Updated `helm/oauth2-proxy/Chart.yaml` to upgrade the `appVersion` from `7.5.1` to `7.7.0`.

### Deployment Template Updates:

* Modified `helm/oauth2-proxy/templates/deployment.yaml` to add new configuration flags and reorganize existing ones. This includes setting cookie properties, passing access tokens, and configuring JWT bearer tokens.
